### PR TITLE
Control-J/-K for Previous/Next notes

### DIFF
--- a/NotesTableView.m
+++ b/NotesTableView.m
@@ -869,9 +869,17 @@ enum { kNext_Tag = 'j', kPrev_Tag = 'k' };
 - (BOOL)performKeyEquivalent:(NSEvent *)theEvent {
 	
 	unsigned mods = [theEvent modifierFlags];
-	if ((mods & NSCommandKeyMask) && ((mods & NSShiftKeyMask) == 0)) {
+	
+	// Also catch Ctrl-J/-K to match the shortcuts of other apps
+	if (((mods & NSCommandKeyMask) || (mods & NSControlKeyMask)) && ((mods & NSShiftKeyMask) == 0)) {
 		
-		unichar keyChar = [theEvent firstCharacter]; /*cannot use ignoringModifiers here as it subverts the Dvorak-Qwerty-CMD keyboard layout */
+		unichar keyChar = ' '; 
+		if (mods & NSCommandKeyMask) {
+			keyChar = [theEvent firstCharacter]; /*cannot use ignoringModifiers here as it subverts the Dvorak-Qwerty-CMD keyboard layout */
+		}
+		if (mods & NSControlKeyMask) {
+			keyChar = [theEvent firstCharacterIgnoringModifiers]; /* first gets '\n' when control key is set, so fall back to ignoringModifiers */
+		}
 		
 		if (keyChar == kNext_Tag || keyChar == kPrev_Tag) {
 			
@@ -886,9 +894,10 @@ enum { kNext_Tag = 'j', kPrev_Tag = 'k' };
 			return YES;
 		}
 	}
-
+	
 	return [super performKeyEquivalent:theEvent];
 }
+
 
 - (void)incrementNoteSelection:(id)sender {
 	


### PR DESCRIPTION
Zachary,

I recently stumbled across your app when I was frustrated with everything else I had tried, and it really is ideal for me. I really dig the philosophy it follows, and am excited to see where you take it. 

Anyway, my only complaint was that I was used to Control-J and Control-K for navigation in other applications (most notably LaunchBar), and wanted to be able to use that in NV. so I extended the performKeyEquivalent method to catch those combinations. I thought this might be good to go back into the base since it does not clobber any existing shortcuts. 

Let me know what you think, and if you want to make this an option, I certainly can do that too. 

Keep up the good work, and thanks for releasing the source in the first place.

-Chris
