### PR TITLE
Updated Control-N/-P keybindings

### DIFF
--- a/NotesTableView.h
+++ b/NotesTableView.h
@@ -88,6 +88,7 @@ typedef struct _ViewLocationContext {
 - (NoteAttributeColumn*)noteAttributeColumnForIdentifier:(NSString*)identifier;
 
 - (void)incrementNoteSelection:(id)sender;
+- (void)incrementNoteSelectionWithDummyItem:(unichar) keyChar;
 
 - (id)labelsListSource;
 - (void)setLabelsListSource:(id)labelsSource;


### PR DESCRIPTION
Zach,

I cleaned up the `performKeyEquivalent` method to refactor out the duplicate code. I wound up adding a method instead of a C function to DRY-up the code a little better, let me know if you like it this way.

While I was in there I added `Control-[` to bring one more the old school UNIX keybindings to NV. I hope this would be benign since it should not clobber anything existing. This was requested by one of my buddies that lives in Vim and insists that it is easier on the wrists. Since it was a UNIX standard I thought it made sense.

-C
