### PR TITLE
Avoid modulo bias in password generator.

### DIFF
--- a/NVPasswordGenerator.m
+++ b/NVPasswordGenerator.m
@@ -44,7 +44,7 @@ static const char nvSymbolSet[] = "!@#$%^&*()-+=?/<>";
     for (i = 0; i < len; ++i) {
         char c;
         do {
-            c = source[arc4random() % srclen];
+            c = source[arc4random_uniform(srclen)];
         } while (0 == (options & knvPasswordDuplicates) && NULL != strchr(gen, c));
         
         gen[i] = c;


### PR DESCRIPTION
If the length of password characters alphabet is not a power of two,
the generated passwords are slightly non-uniform, that is, they
have modulo bias (see http://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#Modulo_bias)

Use arc4random_uniform(srclen) instead of arc4random() % srclen
to generate proper uniformly distributed characters.
