### PR TITLE
Fix incorrect usage of volume capabilities

### DIFF
--- a/FSExchangeObjectsCompat.c
+++ b/FSExchangeObjectsCompat.c
@@ -23,7 +23,7 @@ __private_extern__ u_int32_t volumeCapabilities(const char *path)
     bzero(&vinfo, sizeof(vinfo));
     if (0 == getattrlist(path, &alist, &vinfo, sizeof(vinfo), 0)
         && 0 != (alist.volattr & ATTR_VOL_CAPABILITIES)) {
-        return (vinfo.v_caps.capabilities[VOL_CAPABILITIES_FORMAT]);
+        return (vinfo.v_caps.capabilities[VOL_CAPABILITIES_INTERFACES]);
     }
     
     return (0);


### PR DESCRIPTION
Quick fix for #365, to use the fallback `FSExchangeObjectsEmulate` instead of just failing. Of course it might be nicer to use `renamex_np` with `RENAME_SWAP`, but that is a more complex change. This fix should be applied either way, as long as volume capabilities are still used.