### PR TITLE
Simplenote URI modification

### DIFF
--- a/SimplenoteSession.m
+++ b/SimplenoteSession.m
@@ -64,7 +64,7 @@ static void SNReachabilityCallback(SCNetworkReachabilityRef	target, SCNetworkCon
 	//path example: "/api2/index"
 	
 	NSString *queryStr = params ? [NSString stringWithFormat:@"?%@", [params URLEncodedString]] : @"";
-	return [NSURL URLWithString:[NSString stringWithFormat:@"https://simple-note.appspot.com%@%@", path, queryStr]];
+	return [NSURL URLWithString:[NSString stringWithFormat:@"https://app.simplenote.com%@%@", path, queryStr]];
 }
 
 #if 0


### PR DESCRIPTION
As pointed out by @DEC32768: "Perhaps owing to domain name change from https://simple-note.appspot.com to https://app.simplenote.com" (https://github.com/scrod/nv/issues/382#issue-416511082)