### PR TITLE
Fix the ⌘-F find panel in macOS Big Sur

### DIFF
--- a/AppController.m
+++ b/AppController.m
@@ -1186,6 +1186,7 @@ terminateApp:
     
 	//int numberSelected = [notesTableView numberOfSelectedRows];
 	BOOL enable = /*numberSelected != 1;*/ state;
+	[textView clearFindPanel];
 	[textView setHidden:enable];
 	[editorStatusView setHidden:!enable];
 	
@@ -1242,6 +1243,7 @@ terminateApp:
 		
 		//NSString *words = noteIndex != [notationController preferredSelectedNoteIndex] ? typedString : nil;
 		//[textView setFutureSelectionRange:noteSelectionRange highlightingWords:words];
+		[textView clearFindPanel];
 		
 		return YES;
 	}

--- a/AppController.m
+++ b/AppController.m
@@ -188,7 +188,10 @@ void outletObjectAwoke(id sender) {
 			if (![[prefsController notationPrefs] firstTimeUsed]) {
 				//don't do anything automatically on the first launch; afterwards, check every 4 days, as specified in Info.plist
 				SEL checksSEL = @selector(setAutomaticallyChecksForUpdates:);
-				[updater methodForSelector:checksSEL](updater, checksSEL, YES);
+                typedef void (*UpdaterMethod)(id, SEL, BOOL);
+                UpdaterMethod updaterChecks;
+                updaterChecks = (UpdaterMethod)[updater methodForSelector:checksSEL];
+                updaterChecks(updater, checksSEL, YES);
 			}
 		} else {
 			NSLog(@"Could not load %@!", frameworkPath);

--- a/AppController.m
+++ b/AppController.m
@@ -45,6 +45,7 @@
 #import "InvocationRecorder.h"
 #import "LinearDividerShader.h"
 #import "SecureTextEntryManager.h"
+#import "NSString_CustomTruncation.h"
 
 
 @implementation AppController

--- a/FSExchangeObjectsCompat.h
+++ b/FSExchangeObjectsCompat.h
@@ -8,3 +8,4 @@
 
 OSErr FSExchangeObjectsEmulate(const FSRef *sourceRef, const FSRef *destRef, FSRef *newSourceRef, FSRef *newDestRef);
 Boolean VolumeOfFSRefSupportsExchangeObjects(const FSRef *fsRef);
+u_int32_t volumeCapabilities(const char *path);

--- a/GlobalPrefs.h
+++ b/GlobalPrefs.h
@@ -23,6 +23,7 @@
 
 #import <Cocoa/Cocoa.h>
 #import "SynchronizedNoteProtocol.h"
+#import "BufferUtils.h"
 
 extern NSString *NoteTitleColumnString;
 extern NSString *NoteLabelsColumnString;

--- a/GlobalPrefs.h
+++ b/GlobalPrefs.h
@@ -49,7 +49,7 @@ BOOL ColorsEqualWith8BitChannels(NSColor *c1, NSColor *c2);
 @interface GlobalPrefs : NSObject {
 	NSUserDefaults *defaults;
 	
-	IMP runCallbacksIMP;
+	id (*runCallbacksIMP)(GlobalPrefs*, SEL, SEL, id);
 	NSMutableDictionary *selectorObservers;
 	
 	PTKeyCombo *appActivationKeyCombo;

--- a/LinkingEditor.h
+++ b/LinkingEditor.h
@@ -51,8 +51,9 @@ enum {LAST_FIND_UNKNOWN, LAST_FIND_NO, LAST_FIND_YES};
 	NSString *stringDuringFind;
 	NoteObject *noteDuringFind;
 	
-	IMP defaultIBeamCursorIMP, whiteIBeamCursorIMP;
-}
+    id (*defaultIBeamCursorIMP)(Class, SEL);
+    id (*whiteIBeamCursorIMP)(Class, SEL);
+};
 
 - (NSColor*)_insertionPointColorForForegroundColor:(NSColor*)fgColor backgroundColor:(NSColor*)bgColor;
 - (NSColor*)_linkColorForForegroundColor:(NSColor*)fgColor backgroundColor:(NSColor*)bgColor;

--- a/LinkingEditor.h
+++ b/LinkingEditor.h
@@ -36,6 +36,7 @@ enum {LAST_FIND_UNKNOWN, LAST_FIND_NO, LAST_FIND_YES};
     IBOutlet NotesTableView *notesTableView;
 
 	GlobalPrefs *prefsController;
+	id textFinder;
 	BOOL didRenderFully;
 	
 	BOOL didChangeIntoAutomaticRange;
@@ -44,12 +45,6 @@ enum {LAST_FIND_UNKNOWN, LAST_FIND_NO, LAST_FIND_YES};
 	BOOL isAutocompleting, wasDeleting;
 	
 	BOOL backgroundIsDark, mouseInside;
-	
-	//ludicrous ivars used to hack NSTextFinder. just write your own, damnit!
-	NSRange selectedRangeDuringFind;
-	NSString *lastImportedFindString;
-	NSString *stringDuringFind;
-	NoteObject *noteDuringFind;
 	
     id (*defaultIBeamCursorIMP)(Class, SEL);
     id (*whiteIBeamCursorIMP)(Class, SEL);
@@ -82,7 +77,7 @@ enum {LAST_FIND_UNKNOWN, LAST_FIND_NO, LAST_FIND_YES};
 - (BOOL)_rangeIsAutoIdentedBullet:(NSRange)aRange;
 
 - (void)setupFontMenu;
-
+- (void)clearFindPanel;
 - (BOOL)didRenderFully;
 @end
 

--- a/LinkingEditor.m
+++ b/LinkingEditor.m
@@ -88,8 +88,8 @@ CGFloat _perceptualDarkness(NSColor*a);
 	
 	[[self window] setAcceptsMouseMovedEvents:YES];
 	if (IsLeopardOrLater) {
-		defaultIBeamCursorIMP = method_getImplementation(class_getClassMethod([NSCursor class], @selector(IBeamCursor)));
-		whiteIBeamCursorIMP = method_getImplementation(class_getClassMethod([NSCursor class], @selector(whiteIBeamCursor)));
+        defaultIBeamCursorIMP = (id(*)(Class, SEL))method_getImplementation(class_getClassMethod([NSCursor class], @selector(IBeamCursor)));
+        whiteIBeamCursorIMP = (id(*)(Class, SEL))method_getImplementation(class_getClassMethod([NSCursor class], @selector(whiteIBeamCursor)));
 	}
 
 	didRenderFully = NO;

--- a/NSFileManager_NV.h
+++ b/NSFileManager_NV.h
@@ -24,6 +24,7 @@
 
 
 #import <Cocoa/Cocoa.h>
+#include <sys/xattr.h>
 
 
 @interface NSFileManager (NV)

--- a/Notation.xcodeproj/project.pbxproj
+++ b/Notation.xcodeproj/project.pbxproj
@@ -1858,12 +1858,16 @@
 				LIBRARY_SEARCH_PATHS = "$(LIBRARY_SEARCH_PATHS)";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				MARKETING_VERSION = "2.0 β7";
-				OTHER_CFLAGS = "-I/usr/local/opt/openssl/include";
+				OTHER_CFLAGS = (
+					"-I/usr/local/opt/openssl/include",
+					"-I/opt/homebrew/opt/openssl/include",
+				);
 				OTHER_LDFLAGS = (
 					"-whatsloaded",
 					"-weak_framework",
 					PDFKit,
 					"-L/usr/local/opt/openssl/lib",
+					"-L/opt/homebrew/opt/openssl/lib",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = net.notational.velocity;
 				PRODUCT_NAME = "Notational Velocity";
@@ -1928,8 +1932,14 @@
 				"MACOSX_DEPLOYMENT_TARGET[arch=x86_64]" = 10.9;
 				MARKETING_VERSION = "2.0 β7";
 				ONLY_ACTIVE_ARCH = NO;
-				OTHER_CFLAGS = "-I/usr/local/opt/openssl/include";
-				OTHER_LDFLAGS = "-L/usr/local/opt/openssl/lib";
+				OTHER_CFLAGS = (
+					"-I/usr/local/opt/openssl/include",
+					"-I/opt/homebrew/opt/openssl/include",
+				);
+				OTHER_LDFLAGS = (
+					"-L/usr/local/opt/openssl/lib",
+					"-L/opt/homebrew/opt/openssl/lib",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = net.notational.velocity;
 				PRODUCT_NAME = "Notational Velocity";
 				SDKROOT = macosx;
@@ -1996,11 +2006,15 @@
 				LIBRARY_SEARCH_PATHS = "$(LIBRARY_SEARCH_PATHS)";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				MARKETING_VERSION = "2.0 β7";
-				OTHER_CFLAGS = "-I/usr/local/opt/openssl/include";
+				OTHER_CFLAGS = (
+					"-I/usr/local/opt/openssl/include",
+					"-I/opt/homebrew/opt/openssl/include",
+				);
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					PDFKit,
 					"-L/usr/local/opt/openssl/lib",
+					"-L/opt/homebrew/opt/openssl/lib",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = net.notational.velocity;
 				PRODUCT_NAME = "Notational Velocity";

--- a/NotationPrefsViewController.h
+++ b/NotationPrefsViewController.h
@@ -72,7 +72,7 @@
 	int notesStorageFormatInProgress;
     NotationPrefs *notationPrefs;
 	
-	PassphrasePicker *picker;
+	PassphrasePicker *passphrasePicker;
 	PassphraseChanger *changer;
 
 	BOOL verificationAttempted;

--- a/NotationPrefsViewController.m
+++ b/NotationPrefsViewController.m
@@ -71,7 +71,7 @@ enum {VERIFY_NOT_ATTEMPTED, VERIFY_FAILED, VERIFY_IN_PROGRESS, VERIFY_SUCCESS};
     return self;
 }
 - (void)dealloc {
-	[picker release];
+	[passphrasePicker release];
 	[changer release];
 	[notationPrefs release];
 	[postStorageFormatInvocation release];
@@ -126,7 +126,7 @@ enum {VERIFY_NOT_ATTEMPTED, VERIFY_FAILED, VERIFY_IN_PROGRESS, VERIFY_SUCCESS};
 		
 		//force these objects to re-init with the new notationprefs
 		[changer release]; changer = nil;
-		[picker release]; picker = nil;
+		[passphrasePicker release]; passphrasePicker = nil;
 		
 		[notationPrefs release];
 		notationPrefs = [[[GlobalPrefs defaultPrefs] notationPrefs] retain];
@@ -529,18 +529,18 @@ enum {VERIFY_NOT_ATTEMPTED, VERIFY_FAILED, VERIFY_IN_PROGRESS, VERIFY_SUCCESS};
 		
 		//so queue it up:
 		InvocationRecorder *invRecorder = [InvocationRecorder invocationRecorder];
-		[[invRecorder prepareWithInvocationTarget:picker] showAroundWindow:[view window] resultDelegate:self];
+		[[invRecorder prepareWithInvocationTarget:passphrasePicker] showAroundWindow:[view window] resultDelegate:self];
 		postStorageFormatInvocation = [[invRecorder invocation] retain];
 	}
 }
 
 - (void)enableEncryption {
-	if (!picker) picker = [[PassphrasePicker alloc] initWithNotationPrefs:notationPrefs];
+	if (!passphrasePicker) passphrasePicker = [[PassphrasePicker alloc] initWithNotationPrefs:notationPrefs];
 	
 	int format = [notationPrefs notesStorageFormat];
 	if (format == SingleDatabaseFormat) {
 		
-		[picker showAroundWindow:[view window] resultDelegate:self];
+		[passphrasePicker showAroundWindow:[view window] resultDelegate:self];
 	} else {
 		NSString *formatStrings[] = { NSLocalizedString(@"(WHAT??)",@"user shouldn't see this"), 
 			NSLocalizedString(@"plain text",nil), NSLocalizedString(@"rich text",nil), NSLocalizedString(@"HTML",nil) };
@@ -564,7 +564,7 @@ enum {VERIFY_NOT_ATTEMPTED, VERIFY_FAILED, VERIFY_IN_PROGRESS, VERIFY_SUCCESS};
 	[notationPrefs setDoesEncryption:NO];
 	[self updateRemoveKeychainItemStatus];
 	
-	[picker release]; picker = nil;		
+	[passphrasePicker release]; passphrasePicker = nil;
 }
 
 - (void)disableEncryptionWithWarning:(BOOL)warning {

--- a/SyncSessionController.m
+++ b/SyncSessionController.m
@@ -26,6 +26,7 @@
 #import "SyncServiceSessionProtocol.h"
 #import "NotationDirectoryManager.h"
 #import "SimplenoteSession.h"
+#import <IOKit/pwr_mgt/IOPMLib.h>
 
 //#import <IOKit/IOMessage.h>
 

--- a/WALController.m
+++ b/WALController.m
@@ -32,6 +32,33 @@
 #import "NSCollection_utils.h"
 #import "NSString_NV.h"
 
+/*
+ CFHashBytes from http://www.opensource.apple.com/source/CF/CF-1153.18/CFUtilities.c
+ */
+#define ELF_STEP(B) T1 = (H << 4) + B; T2 = T1 & 0xF0000000; if (T2) T1 ^= (T2 >> 24); T1 &= (~T2); H = T1;
+
+CFHashCode CFHashBytes(uint8_t *bytes, CFIndex length) {
+    /* The ELF hash algorithm, used in the ELF object file format */
+    UInt32 H = 0, T1, T2;
+    SInt32 rem = (SInt32)length;
+    while (3 < rem) {
+        ELF_STEP(bytes[length - rem]);
+        ELF_STEP(bytes[length - rem + 1]);
+        ELF_STEP(bytes[length - rem + 2]);
+        ELF_STEP(bytes[length - rem + 3]);
+        rem -= 4;
+    }
+    switch (rem) {
+        case 3:  ELF_STEP(bytes[length - 3]);
+        case 2:  ELF_STEP(bytes[length - 2]);
+        case 1:  ELF_STEP(bytes[length - 1]);
+        case 0:  ;
+    }
+    return H;
+}
+
+#undef ELF_STEP
+
 //file descriptor based for lower level access
 
 //also used as an ad-hoc lock file;


### PR DESCRIPTION
The find panel wasn't working in (at least) Big Sur, so this implementation uses NSTextFinder directly.

This PR also includes changes needed to get the project to build on Xcode 12 on Big Sur. As a bonus, it will also build natively on an M1 Mac.